### PR TITLE
Añadir dependencias vulnerables con fines educativos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    
+
+    // ⚠️ DEPENDENCIAS VULNERABLES - SOLO CON FINES EDUCATIVOS ⚠️
+    // Log4j 1.2.17 - CVE-2019-17571 (deserialización remota no autenticada)
+    implementation 'log4j:log4j:1.2.17'
+    // Jackson-databind 2.9.10 - CVE-2019-17267, CVE-2020-8840 (polimorfismo peligroso)
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
+    // Commons-collections 3.1 - vulnerabilidad clásica de deserialización Java
+    implementation 'commons-collections:commons-collections:3.1'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-    // ⚠️ DEPENDENCIAS VULNERABLES - SOLO CON FINES EDUCATIVOS ⚠️
-    // Log4j 1.2.17 - CVE-2019-17571 (deserialización remota no autenticada)
     implementation 'log4j:log4j:1.2.17'
-    // Jackson-databind 2.9.10 - CVE-2019-17267, CVE-2020-8840 (polimorfismo peligroso)
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
-    // Commons-collections 3.1 - vulnerabilidad clásica de deserialización Java
     implementation 'commons-collections:commons-collections:3.1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/demo/controller/DeserializeController.java
+++ b/src/main/java/com/example/demo/controller/DeserializeController.java
@@ -1,0 +1,16 @@
+package com.example.demo.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/deserialize")
+public class DeserializeController {
+
+    @PostMapping
+    public Object deserialize(@RequestBody String json) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        return mapper.readValue(json, Object.class);
+    }
+}


### PR DESCRIPTION
Closes #58. Añade Log4j 1.2.17, jackson-databind 2.9.10 y commons-collections 3.1, junto con un endpoint que explota la deserialización polimórfica de Jackson.