### PR TITLE
Arreglar build por dependencia Jackson incompatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     implementation 'log4j:log4j:1.2.17'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
     implementation 'commons-collections:commons-collections:3.1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
Se elimina la versión fija de jackson-databind para evitar incompatibilidad con Spring Boot 3.2.2 y restaurar el build.\n\nCloses #85